### PR TITLE
fix: reject sending a message to a nonexistent user

### DIFF
--- a/src/__tests__/message.usecase.test.ts
+++ b/src/__tests__/message.usecase.test.ts
@@ -22,6 +22,7 @@ import { AppError, ErrorType } from '@/utils/errorHandler';
 // モックリポジトリの作成
 const createMockRepository = (): jest.Mocked<IMessageRepository> => ({
   create: jest.fn(),
+  userExists: jest.fn(),
   findByReceiverId: jest.fn(),
   findBySenderId: jest.fn(),
   findById: jest.fn(),
@@ -98,11 +99,13 @@ describe('SendMessageUseCase', () => {
         receiver_id: 'user2',
       };
       const mockMessage = createMockMessage();
+      mockRepo.userExists.mockResolvedValue(true);
       mockRepo.create.mockResolvedValue(mockMessage);
 
       const result = await useCase.execute(input);
 
       expect(result).toEqual(mockMessage);
+      expect(mockRepo.userExists).toHaveBeenCalledWith('user2');
       expect(mockRepo.create).toHaveBeenCalledWith(input);
     });
   });
@@ -163,6 +166,23 @@ describe('SendMessageUseCase', () => {
       await expect(useCase.execute(input)).rejects.toThrow(AppError);
       expect(mockRepo.create).not.toHaveBeenCalled();
     });
+
+    it('受信者が存在しない場合はAppErrorをスローし、DBへの書き込みは行わない', async () => {
+      const input = {
+        subject: 'テスト件名',
+        body: 'テスト本文',
+        sender_id: 'user1',
+        receiver_id: 'nonexistent-user',
+      };
+      mockRepo.userExists.mockResolvedValue(false);
+
+      await expect(useCase.execute(input)).rejects.toThrow(AppError);
+      await expect(useCase.execute(input)).rejects.toMatchObject({
+        type: ErrorType.VALIDATION,
+        statusCode: 400,
+      });
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('異常系 - データベースエラー', () => {
@@ -173,6 +193,7 @@ describe('SendMessageUseCase', () => {
         sender_id: 'user1',
         receiver_id: 'user2',
       };
+      mockRepo.userExists.mockResolvedValue(true);
       mockRepo.create.mockRejectedValue(new Error('DB error'));
 
       await expect(useCase.execute(input)).rejects.toThrow(AppError);
@@ -190,6 +211,7 @@ describe('SendMessageUseCase', () => {
         receiver_id: 'user2',
       };
       const appError = new AppError('Not Found', ErrorType.NOT_FOUND, 404);
+      mockRepo.userExists.mockResolvedValue(true);
       mockRepo.create.mockRejectedValue(appError);
 
       await expect(useCase.execute(input)).rejects.toBe(appError);

--- a/src/__tests__/messages.api.test.ts
+++ b/src/__tests__/messages.api.test.ts
@@ -21,11 +21,16 @@ jest.mock('@prisma/client', () => {
     update: jest.fn(),
     delete: jest.fn(),
   };
+  const mockUser = {
+    findUnique: jest.fn(),
+  };
   return {
     PrismaClient: jest.fn().mockImplementation(() => ({
       message: mockMessage,
+      user: mockUser,
     })),
     __mockMessage: mockMessage,
+    __mockUser: mockUser,
   };
 });
 
@@ -54,6 +59,7 @@ import { PATCH as patchRead } from '@/app/api/messages/[message_id]/read/route';
 
 const mockGetUserId = getUserIdFromRequest as jest.MockedFunction<typeof getUserIdFromRequest>;
 const mockPrismaMessage = (require('@prisma/client') as any).__mockMessage;
+const mockPrismaUser = (require('@prisma/client') as any).__mockUser;
 
 /** テスト用メッセージデータ */
 const mockMessageData = {
@@ -129,6 +135,7 @@ describe('POST /api/messages', () => {
 
   it('有効なデータでメッセージを送信できる', async () => {
     mockGetUserId.mockReturnValue('user1');
+    mockPrismaUser.findUnique.mockResolvedValue({ id: 'user2', user_name: '受信者' });
     mockPrismaMessage.create.mockResolvedValue(mockMessageData);
 
     const req = createRequest('POST', 'http://localhost/api/messages', {
@@ -141,6 +148,23 @@ describe('POST /api/messages', () => {
 
     expect(res.status).toBe(201);
     expect(data.subject).toBe('テスト件名');
+  });
+
+  it('存在しない受信者IDの場合は400を返し、DBへの書き込みは行わない', async () => {
+    mockGetUserId.mockReturnValue('user1');
+    mockPrismaUser.findUnique.mockResolvedValue(null);
+
+    const req = createRequest('POST', 'http://localhost/api/messages', {
+      subject: 'テスト件名',
+      body: 'テスト本文',
+      receiver_id: 'nonexistent-user-id',
+    });
+    const res = await postMessage(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.type).toBe(ErrorType.VALIDATION);
+    expect(mockPrismaMessage.create).not.toHaveBeenCalled();
   });
 
   it('未認証の場合は401を返す', async () => {

--- a/src/application/message/SendMessageUseCase.ts
+++ b/src/application/message/SendMessageUseCase.ts
@@ -36,6 +36,7 @@ export class SendMessageUseCase {
    * @param input - 送信するメッセージのデータ
    * @returns 作成されたメッセージ（ユーザー情報付き）
    * @throws {AppError} バリデーションエラーの場合（VALIDATION, 400）
+   * @throws {AppError} 受信者が存在しない場合（VALIDATION, 400）
    * @throws {AppError} データベースエラーの場合（DATABASE_ERROR, 500）
    */
   async execute(input: SendMessageInput): Promise<MessageWithUsers> {
@@ -56,6 +57,15 @@ export class SendMessageUseCase {
     }
 
     try {
+      const receiverExists = await this.messageRepository.userExists(data.receiver_id);
+      if (!receiverExists) {
+        throw new AppError(
+          '指定された受信者が存在しません',
+          ErrorType.VALIDATION,
+          400
+        );
+      }
+
       return await this.messageRepository.create(data);
     } catch (error) {
       if (error instanceof AppError) {

--- a/src/domain/message/MessageRepository.ts
+++ b/src/domain/message/MessageRepository.ts
@@ -13,6 +13,17 @@ export interface IMessageRepository {
   create(data: CreateMessageData): Promise<MessageWithUsers>;
 
   /**
+   * 指定ユーザーIDのユーザーが存在するかを確認する
+   *
+   * メッセージ作成時、受信者IDが実在するユーザーを指すことを
+   * DB書き込み前に検証するために使用する。
+   *
+   * @param userId - 確認対象のユーザーID
+   * @returns ユーザーが存在すれば `true`、存在しなければ `false`
+   */
+  userExists(userId: string): Promise<boolean>;
+
+  /**
    * 指定ユーザーの受信トレイを取得する
    *
    * @param userId - 対象ユーザーID

--- a/src/infrastructure/message/PrismaMessageRepository.ts
+++ b/src/infrastructure/message/PrismaMessageRepository.ts
@@ -38,6 +38,20 @@ export class PrismaMessageRepository implements IMessageRepository {
   }
 
   /**
+   * 指定ユーザーIDのユーザーが存在するかを確認する
+   *
+   * @param userId - 確認対象のユーザーID
+   * @returns ユーザーが存在すれば `true`、存在しなければ `false`
+   */
+  async userExists(userId: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    });
+    return user !== null;
+  }
+
+  /**
    * 指定ユーザーの受信トレイを取得する（新しい順）
    *
    * @param userId - 受信者ユーザーID


### PR DESCRIPTION
## Summary
`SendMessageUseCase` validated subject/body/receiver_id presence but never checked the receiver actually exists, so a bogus `receiver_id` tripped a DB foreign-key violation and surfaced as a 500 instead of a 400. Not reachable via the compose UI (recipients come from `/api/users`) but reachable via direct API calls.

Added `IMessageRepository.userExists()` and have `SendMessageUseCase` check it before writing.

## Test plan
- [x] `npm test` — 12 suites / 202 tests passing
- [x] Verified live: bogus `receiver_id` now 400, valid send still 201